### PR TITLE
基本的な設定を追加

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,2 +1,11 @@
-[*.{c,cc,cpp,cxx,h,hh,hpp,hxx}]
+﻿root = true
+
+[*]
+end_of_line = crlf
 charset = utf-8-bom
+trim_trailing_whitespace = true
+insert_final_newline = false
+
+[*.{c,cc,cpp,cxx,h,hh,hpp,hxx}]
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
・すべてのファイルに対して
改行コードをCRLFに指定
文字コードをUTF-8-BOMに指定
行末のスペースを削除
ファイルの最終行に改行を挿入しない

・C/C++のソースファイルに対して
インデントはスペースで行う
インデント幅は4とする